### PR TITLE
Change market and assessed values to object keyed to years

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -85,10 +85,14 @@ var Parser = (function Parser(){
 			'deedPage'        : deedPage,
 			'abatement'       : abatement,
 			'lotArea'         : lotArea,
-			'twentyFifteenFullMarketValue'     : twentyFifteenFmv,
-			'twentyFifteenCountyAssessedValue' : twentyFifteenCav,
-			'twentyFourteenFullMarketValue'    : twentyFourteenFmv,
-			'twentyFourteenCountyAssessedValue': twentyFourteenCav
+			'fullMarketValues'    : {
+				'2015' : twentyFifteenFmv,
+				'2014' : twentyFourteenFmv
+			},
+			'countyAssessedValues' : {
+				'2015' : twentyFifteenCav,
+				'2014' : twenthFourteenFmv
+			}
 		};
 		
 		return parcel;

--- a/readme.md
+++ b/readme.md
@@ -62,26 +62,30 @@ Returns general information about a parcel.
 		deedPage: '0',
 		abatement: 'No',
 		lotArea: 2,
-		twentyFifteenFullMarketValue: { 
-			landValue: 7063200,
-			buildingValue: 94595700,
-			totalValue: 101658900 
+		fullMarketValues: {
+			2015:  {
+				landValue: 7063200,
+				buildingValue: 94595700,
+				totalValue: 101658900 
+			},
+			2014: {
+				landValue: 7063200,
+				buildingValue: 94595700,
+				totalValue: 101658900 
+			}
 		},
-		twentyFifteenCountyAssessedValue: {
-			landValue: 7063200,
-			buildingValue: 94595700,
-			totalValue: 101658900 
-		},
-		twentyFourteenFullMarketValue: { 
-			landValue: 7063200,
-			buildingValue: 94595700,
-			totalValue: 101658900 
-		},
-		twentyFourteenCountyAssessedValue: { 
-			landValue: 7063200,
-			buildingValue: 94595700,
-			totalValue: 101658900 
-		}	
+		countyAssessedValues:  {
+			2015: {
+				landValue: 7063200,
+				buildingValue: 94595700,
+				totalValue: 101658900 
+			},
+			2014: {
+				landValue: 7063200,
+				buildingValue: 94595700,
+				totalValue: 101658900 
+			}
+		}
 	};
 
 ###buildingInfo(parcelId, errback)
@@ -377,26 +381,30 @@ Gets all of the parcels on a given block - streetName can match many street name
 		deedPage: '0',
 		abatement: 'No',
 		lotArea: 2,
-		twentyFifteenFullMarketValue: {
-			landValue: 7063200,
-			buildingValue: 94595700,
-			totalValue: 101658900
+		fullMarketValues: {
+			2015: {
+				landValue: 7063200,
+				buildingValue: 94595700,
+				totalValue: 101658900
+			},
+			2014: {
+				landValue: 7063200,
+				buildingValue: 94595700,
+				totalValue: 101658900
+			}
 		},
-		twentyFifteenCountyAssessedValue: {
-			landValue: 7063200,
-			buildingValue: 94595700,
-			totalValue: 101658900
+		countyAssessedValues: {
+			2015: {
+				landValue: 7063200,
+				buildingValue: 94595700,
+				totalValue: 101658900
+			},
+			2014: {
+				landValue: 7063200,
+				buildingValue: 94595700,
+				totalValue: 101658900
+			}
 		},
-		twentyFourteenFullMarketValue: {
-			landValue: 7063200,
-			buildingValue: 94595700,
-			totalValue: 101658900
-		},
-		twentyFourteenCountyAssessedValue: {
-			landValue: 7063200,
-			buildingValue: 94595700,
-			totalValue: 101658900
-		}
 	},{
 		parcelId: '0009-P-00050-0000-00',
 		municipality: '102  PITTSBURGH - 2ND WARD',
@@ -416,26 +424,30 @@ Gets all of the parcels on a given block - streetName can match many street name
 		deedPage: '322',
 		abatement: 'No',
 		lotArea: 2,
-		twentyFifteenFullMarketValue: {
-			landValue: 12000000,
-			buildingValue: 111500000,
-			totalValue: 123500000
+		fullMarketValues: {
+			2015: {
+				landValue: 12000000,
+				buildingValue: 111500000,
+				totalValue: 123500000
+			},
+			2014: {
+				landValue: 12000000,
+				buildingValue: 111500000,
+				totalValue: 123500000
+			}
 		},
-		twentyFifteenCountyAssessedValue: {
-			landValue: 12000000,
-			buildingValue: 111500000,
-			totalValue: 123500000
+		countyAssessedValues: {
+			2015: {
+				landValue: 12000000,
+				buildingValue: 111500000,
+				totalValue: 123500000
+			},
+			2014: {
+				landValue: 12000000,
+				buildingValue: 111500000,
+				totalValue: 123500000
+			}
 		},
-		twentyFourteenFullMarketValue: {
-			landValue: 12000000,
-			buildingValue: 111500000,
-			totalValue: 123500000
-		},
-		twentyFourteenCountyAssessedValue: {
-			landValue: 12000000,
-			buildingValue: 111500000,
-			totalValue: 123500000
-		}
 	},{
 		// ...
 	}]


### PR DESCRIPTION
The current API hardcodes the years for market and assessed values for 2014 and 2015, spelled out as words. These are more usefully presented to the API user as numeric values, as this is how they are more likely to come across them in other sources, and permits writing more generalized code. I also think this aligns better with API users' expectations; it would be surprising for new property names to be added to the API as more annual data is added, but the fullMarketValues and countyAssessedValues objects in the proposed change behave more like sparse arrays. Array indices are typically not considered static parts of an API, and users will be less surprised when they change.

I should also point out that I did this without any testing at all, as I lack a test environment on this machine. :) Though I scrutinized the code closely, I apologize for any errors. I intend this to be a conversation starter; if you choose to accept the change, I will run tests sufficient to ensure good behavior.
